### PR TITLE
Update colors for Sublime 3103

### DIFF
--- a/One Dark.tmTheme
+++ b/One Dark.tmTheme
@@ -107,11 +107,11 @@
 			<key>name</key>
 			<string>Variables</string>
 			<key>scope</key>
-			<string>variable</string>
+			<string>variable, meta.property.object, string.unquoted.label</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#E06C75</string>
+				<string>#ABB2BF</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Recently released build 3103 of Sublime changes quite a few things about how syntax highlighting works (https://github.com/sublimehq/Packages/issues/141), so this is my attempt at restoring the looks of this color scheme to what it looked like before the update.